### PR TITLE
Potential fix for code scanning alert no. 77: Server-side request forgery

### DIFF
--- a/turing-app/src/main/java/com/viglet/turing/api/ocr/TurOcrAPI.java
+++ b/turing-app/src/main/java/com/viglet/turing/api/ocr/TurOcrAPI.java
@@ -51,9 +51,14 @@ public class TurOcrAPI {
 
     @PostMapping("/url")
     public TurFileAttributes urlToText(@RequestBody TurOcrFromUrl turOcrFromUrl) {
+        String urlString = turOcrFromUrl.getUrl();
+        if (!TurFileUtils.isAllowedRemoteUrlString(urlString)) {
+            log.warn("Blocked OCR request for disallowed URL: {}", urlString);
+            return new TurFileAttributes();
+        }
         try {
-            return TurFileUtils.urlContentToText(URI.create(turOcrFromUrl.getUrl()).toURL());
-        } catch (MalformedURLException e) {
+            return TurFileUtils.urlContentToText(URI.create(urlString).toURL());
+        } catch (IllegalArgumentException | MalformedURLException e) {
             log.error(e.getMessage(), e);
         }
         return new TurFileAttributes();


### PR DESCRIPTION
Potential fix for [https://github.com/openviglet/turing/security/code-scanning/77](https://github.com/openviglet/turing/security/code-scanning/77)

In general, fixing this SSRF issue means: (a) treating the OCR `/url` endpoint input as untrusted, (b) validating it against strict rules (for example, only specific allowed domains or URL prefixes), and (c) ensuring that *every* network request, including after redirects, is only made to hosts that pass those same rules and IP checks. Additionally, we must ensure that the code never attempts to use a `HttpURLConnection` if the safety checks fail.

The best targeted fix, without changing existing functionality, is:

1. In `TurOcrAPI.urlToText`, validate the incoming URL before calling into `TurFileUtils`. We can reuse the existing validation logic by adding a static helper in `TurFileUtils` (e.g. `public static boolean isAllowedRemoteUrlString(String url)`) that:
   - Safely parses the string to a `URL`, returning `false` on any error.
   - Calls the existing `isAllowedRemoteUrl(URL)` on the parsed URL.
   This lets the API short‑circuit invalid or disallowed URLs with a predictable result (`new TurFileAttributes()`).

2. In `TurFileUtils.copyURLToFileSafe`, ensure that if `createConnection(currentUrl)` returns `null` (meaning the host/IP is not safe), we *stop* and throw an `IOException` rather than dereferencing `connection`. This guarantees that no HTTP request is made when safety checks fail.

3. In `TurFileUtils.createConnection`, keep existing safety checks, but it’s important they are actually enforced by callers (step 2 makes that true). We do not change behaviour otherwise.

We only touch the shown snippets in `TurFileUtils.java` and `TurOcrAPI.java`. No new external dependencies are required; we only use Java’s standard library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
