### PR TITLE
Potential fix for code scanning alert no. 78: Server-side request forgery

### DIFF
--- a/turing-app/src/main/java/com/viglet/turing/api/integration/TurIntegrationAPI.java
+++ b/turing-app/src/main/java/com/viglet/turing/api/integration/TurIntegrationAPI.java
@@ -118,15 +118,32 @@ public class TurIntegrationAPI {
      * starts with the expected API prefix.
      */
     private boolean isValidProxyPath(String path) {
-        if (path == null)
-            return false;
-        // Must start with allowed prefix after normalization (prevent access to
-        // internal endpoints)
-        if (!path.startsWith("/api/")) {
+        if (path == null) {
             return false;
         }
+        // Normalize the path first to eliminate any ./ or ../ segments
         String normalized = Paths.get(path).normalize().toString();
-        // Disallow any attempts at directory traversal
-        return !normalized.contains("..");
+
+        // Ensure the normalized path still starts with the expected API prefix.
+        // This prevents proxying to arbitrary internal endpoints.
+        if (!normalized.startsWith("/api/")) {
+            return false;
+        }
+
+        // Disallow any attempts at directory traversal in the normalized path
+        if (normalized.contains("..")) {
+            return false;
+        }
+
+        // Optionally, restrict characters in the path to a safe subset
+        // (alphanumeric, slash, dash, underscore, dot).
+        for (int i = 0; i < normalized.length(); i++) {
+            char c = normalized.charAt(i);
+            if (!(Character.isLetterOrDigit(c) || c == '/' || c == '-' || c == '_' || c == '.')) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/openviglet/turing/security/code-scanning/78](https://github.com/openviglet/turing/security/code-scanning/78)

In general, to fix SSRF issues in proxy-style endpoints, you should ensure that user input cannot arbitrarily influence the target of the outbound request. Common strategies include: (1) restricting outbound requests to a fixed host/scheme and a well-defined path prefix, (2) validating and normalizing the path to prevent traversal or access to unintended internal APIs, and (3) optionally using an allowlist of specific paths. You already enforce same host/scheme and a basic `/api/` prefix with a check against `".."`; we can tighten this to make SSRF harder and satisfy the static analyzer.

The best fix here, without changing existing functionality, is to enhance `isValidProxyPath` so that it more robustly validates the path derived from `request.getRequestURI()`. We will:  
- Normalize the path using `Paths.get(...).normalize()` and ensure the normalized path still begins with the allowed prefix `/api/`.  
- Explicitly reject paths containing suspicious sequences such as `".."` or URL-encoded traversal attempts (e.g. `%2e%2e`).  
- Optionally, ensure the path only contains expected characters (letters, digits, `/`, `-`, `_`, `.`, etc.) so that obviously malformed or encoded attempts are rejected.

All changes will be limited to `TurIntegrationAPI.isValidProxyPath` in `turing-app/src/main/java/com/viglet/turing/api/integration/TurIntegrationAPI.java`. No new imports are strictly necessary since `Paths` is already imported and we can rely on `String` operations and possibly a simple regex. The `proxy` method remains the same in behavior other than causing some previously-accepted malicious paths to be rejected with 403.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
